### PR TITLE
Add feature launch manual for licensing and RBAC alignment

### DIFF
--- a/docs/reports/rbac-licensing-integration-status.md
+++ b/docs/reports/rbac-licensing-integration-status.md
@@ -1,0 +1,48 @@
+# RBAC ↔ Licensing Integration Status & Readiness Report
+
+## 1. Purpose
+This report summarizes how the current Role-Based Access Control (RBAC) stack and the Licensing Studio work together, outlines the end-to-end feature delivery workflow, and calls out remaining gaps to address before long-term growth.
+
+## 2. Current Integration Snapshot
+
+### 2.1 Service Orchestration & Dependency Injection
+- `LicensingService` coordinates product offerings, feature bundles, surface bindings, and tenant license assignments through a single orchestrator that spans CRUD operations, combined RBAC/licensing access checks, and provisioning flows.【F:src/services/LicensingService.ts†L1-L340】
+- `UserRoleService` injects `LicensingService` so RBAC evaluations always consider licensing. Helper methods gate surfaces by intersecting RBAC-permitted metadata with licensed surfaces and expose convenience APIs for “locked” experiences.【F:src/services/UserRoleService.ts†L10-L214】
+- Permission helper utilities wrap these services so the rest of the app can perform unified access checks with one call, further tightening the integration surface.【F:src/lib/rbac/permissionHelpers.ts†L1-L116】
+
+### 2.2 Metadata Runtime Alignment
+- The metadata context builder now hydrates evaluation contexts with RBAC role arrays, license bundles, and tenant surface entitlements so XML-authored experiences can respect both authorization domains without bespoke code.【F:src/lib/metadata/contextBuilder.ts†L34-L193】
+- The interpreter and evaluation pipeline accept multiple roles and license metadata, ensuring `<RBAC>` directives and expressions resolve against the combined context when rendering runtime overlays.【F:src/lib/metadata/evaluation.ts†L1-L120】
+
+### 2.3 API Surface & Tooling
+- A dedicated RBAC+licensing access endpoint exposes combined checks for external automation or UI clients, returning granular reasons for denials and relying on the same service stack used in-app.【F:src/app/api/rbac/check-access/route.ts†L1-L120】
+- Licensing Studio centralizes admin workflows across product offerings, feature bundles, tenant assignments, and analytics, making it the primary console for governing entitlements alongside RBAC tooling.【F:src/components/admin/licensing/LicensingStudio.tsx†L3-L60】
+- The RBAC Surface Binding Manager surfaces licensing coverage by feature code and lets administrators map metadata surfaces, RBAC roles, and licensing bundles in one place, closing the loop between metadata and entitlement configuration.【F:src/components/admin/rbac/SurfaceBindingManager.tsx†L720-L840】
+
+### 2.4 Operational Readiness
+- Phase 5 hardening delivered materialized view orchestration, caching, and monitoring for RBAC/licensing datasets, establishing GA readiness and observability for combined access pipelines.【F:PHASE_5_IMPLEMENTATION_REPORT.md†L1-L109】
+- The rollout plan documents phased deployment toggles, health criteria, and operational checklists from internal testing through general availability, ensuring the platform can go live safely.【F:docs/deployment/licensing-rollout-plan.md†L1-L120】
+
+## 3. Feature Lifecycle: From Idea to Enforced Access
+1. **Model the capability** – Define or update license bundles, offerings, and surface bindings in the Licensing Studio so the entitlement exists in the catalog and can be tied to metadata and RBAC artifacts.【F:src/services/LicensingService.ts†L73-L340】【F:src/components/admin/licensing/LicensingStudio.tsx†L25-L60】
+2. **Author metadata** – Create or adjust XML blueprints/overlays in `metadata/authoring`, compile them with the provided CLI, and rely on `<RBAC>` directives to scope visibility. This metadata-first approach keeps UI evolution declarative and versioned.【F:docs/architecture/metadata-architecture.md†L6-L55】
+3. **Bind to RBAC & licensing** – Use the Surface Binding Manager to associate metadata surfaces with roles and required feature codes so the runtime intersection enforces both RBAC roles and license bundles.【F:src/components/admin/rbac/SurfaceBindingManager.tsx†L720-L840】
+4. **Provision & assign** – During onboarding or manual adjustments, `LicensingService` provisions tenant features and records license history while `UserRoleService` seeds default roles; admins can reassign offerings through the Licensing Studio when plans change.【F:src/services/LicensingService.ts†L343-L435】【F:docs/phase4-tenant-subscription-onboarding-report.md†L460-L488】
+5. **Runtime enforcement** – Metadata contexts and permission helpers apply the combined RBAC/licensing decision whenever a user loads a surface or API, guaranteeing that both domains remain synchronized as tenants evolve.【F:src/lib/metadata/contextBuilder.ts†L58-L93】【F:src/lib/rbac/permissionHelpers.ts†L16-L99】
+6. **Monitor & iterate** – Materialized view refresh services, caching, and rollout guardrails keep access data fresh and observable so new features can launch safely and be expanded to additional tenants over time.【F:PHASE_5_IMPLEMENTATION_REPORT.md†L15-L109】【F:docs/deployment/licensing-rollout-plan.md†L21-L94】
+
+## 4. Readiness Assessment
+- **Architecture** – RBAC and licensing now converge at the service, metadata, and API layers, preventing drift between menu exposure, metadata overlays, and entitlement catalogs.【F:src/services/UserRoleService.ts†L168-L214】【F:src/lib/metadata/contextBuilder.ts†L58-L93】
+- **Tooling** – Admin consoles cover the critical workflows (catalog management, binding oversight, analytics), minimizing manual SQL or Supabase work for day-to-day operations.【F:src/components/admin/licensing/LicensingStudio.tsx†L25-L60】【F:src/components/admin/rbac/SurfaceBindingManager.tsx†L720-L840】
+- **Operations** – Refresh orchestration, caching, and documented rollout steps indicate the stack is production-ready with defined guardrails and observability hooks.【F:PHASE_5_IMPLEMENTATION_REPORT.md†L15-L109】【F:docs/deployment/licensing-rollout-plan.md†L21-L94】
+
+Overall, the system is technically ready to go live and to support continuous feature delivery, provided the outstanding improvements below are prioritized.
+
+## 5. Gaps & Improvement Opportunities
+1. **Tier-aware RBAC seeding** – During onboarding, default roles are created without tier-specific permissions even though the tier is known. Automating bundle assignment per tier would prevent manual follow-up and align roles with licensed capabilities from day one.【F:docs/phase4-tenant-subscription-onboarding-report.md†L472-L503】
+2. **License tier derivation** – The metadata context currently infers a tenant’s tier from only the first active offering, which can mask multi-offering or add-on scenarios. Expanding this to aggregate active offerings would yield more accurate feature flagging and UI behavior.【F:src/lib/metadata/contextBuilder.ts†L75-L92】
+3. **Provisioning resilience** – `LicensingService.provisionTenantLicense` performs iterative Supabase inserts without transactional safeguards. Wrapping grants in a transaction and capturing partial-failure telemetry would harden onboarding against mid-flight errors.【F:src/services/LicensingService.ts†L355-L402】
+4. **Catalog-to-metadata traceability** – While the Surface Binding Manager lists bound surfaces, there is no automated report that flags license features lacking metadata coverage or RBAC bindings. Extending analytics to highlight these gaps would prevent “orphaned” offerings as the catalog grows.【F:src/components/admin/rbac/SurfaceBindingManager.tsx†L720-L799】
+5. **Plan-level automation scripts** – The rollout playbook references manual SQL for pilot tenant flags and health checks. Packaging these steps into repeatable scripts or CLI tasks would streamline staged rollouts and reduce operator error.【F:docs/deployment/licensing-rollout-plan.md†L61-L94】
+
+Addressing these items will tighten the feedback loop between licensing decisions, metadata authoring, and RBAC enforcement, ensuring StewardTrack remains adaptable as new product tiers and features are introduced.

--- a/docs/user-manual/README.md
+++ b/docs/user-manual/README.md
@@ -6,6 +6,25 @@ Welcome to the StewardTrack User Documentation! This folder contains comprehensi
 
 ## 📚 Available Guides
 
+### Feature Launch & Operations
+
+Step-by-step manuals that connect product delivery with licensing and RBAC:
+
+#### 1. [Feature Launch Manual](./feature-launch-user-manual.md) 🛫
+**Best for**: Cross-functional teams preparing a new capability for go-live
+- **Length**: Medium (20-minute read)
+- **Audience**: Product owners, developers, licensing ops, RBAC admins
+- **Contents**:
+  - Lifecycle overview from idea to launch
+  - Metadata authoring checklist
+  - Licensing Studio configuration steps
+  - RBAC alignment and launch readiness
+
+**When to use**:
+- Planning a brand-new feature or major enhancement
+- Coordinating work between product, licensing, and security teams
+- Auditing whether a feature is ready for deployment
+
 ### Licensing Studio Documentation
 
 Comprehensive guides for managing your church software licensing system:

--- a/docs/user-manual/feature-launch-user-manual.md
+++ b/docs/user-manual/feature-launch-user-manual.md
@@ -1,0 +1,133 @@
+# StewardTrack Feature Launch Manual
+
+## Purpose of This Guide
+This manual walks product owners, designers, and developers through the full journey of shipping a brand-new capability in StewardTrack—from the first idea, to metadata implementation, into Licensing Studio, and finally through RBAC launch readiness. Each step uses plain language and checklists so new teammates can follow along without prior system knowledge.
+
+---
+
+## End-to-End Lifecycle at a Glance
+
+| Stage | Goal | Primary Owners | Key Outputs |
+| --- | --- | --- | --- |
+| 0. Kickoff | Align on what we are building and why | Product + Stakeholders | Feature brief, success metrics |
+| 1. Design & Author | Capture the user experience and data rules in metadata | Product + UX + Developers | Metadata blueprint, acceptance notes |
+| 2. Build & Validate | Implement metadata, connect data sources, and test locally | Developers | Compiled metadata, passing smoke tests |
+| 3. Licensing Setup | Make sure the feature can be sold and packaged | Product Ops | Feature record, bundle assignment, product tier updates |
+| 4. RBAC Alignment | Ensure the right people can see and use it | Security Admins | Permissions, roles, surface bindings |
+| 5. Launch Readiness | Confirm everything works together before go-live | Cross-functional squad | Launch checklist, approval to deploy |
+
+Keep this table nearby—it is the "You Are Here" map for the rest of the guide.
+
+---
+
+## Stage 0 – Kickoff & Preparation
+
+**Goal:** Create a shared understanding of the feature before any files are touched.
+
+1. **Write a one-page feature brief.** Capture the user problem, target audience, and "definition of done." Store it in your team workspace.
+2. **List the systems impacted.** Note whether the feature touches metadata pages, backend services, analytics, or external APIs.
+3. **Confirm licensing intent early.** Decide whether the feature is part of an existing tier or a new upsell so the Licensing Studio steps are not a surprise later.
+4. **Schedule a feature readiness huddle.** Bring product, development, licensing ops, and RBAC admins together. Review the lifecycle table and assign owners.
+5. **Create your Git branch.** Use the naming convention `feature/<short-name>` so changes are easy to track. Run `npm install` if this is your first time on the repo.
+
+> ✅ **Output:** Feature brief, ownership list, active branch, and a clear go/no-go decision to enter Stage 1.
+
+---
+
+## Stage 1 – Design & Metadata Authoring Plan
+
+**Goal:** Translate the feature concept into clear metadata artifacts.
+
+1. **Sketch the user flow.** Whiteboard the screens and key actions. Identify which existing page metadata can be extended versus needing a new definition.
+2. **Locate the authoring folder.** All metadata blueprints live under `metadata/authoring`, organized by domain and page type.【F:docs/architecture/metadata-architecture.md†L1-L34】
+3. **Decide on overlays vs. new pages.** If you are enhancing an existing page, plan to add an overlay XML file. New surfaces get their own folder with `page.xml` and optional overlays.
+4. **Document data needs.** List API endpoints, table queries, and any computed values the metadata must expose. Clarify if new Supabase views or actions are required.
+5. **Draft metadata acceptance notes.** Before coding, write bullet points for what you expect to see (fields, buttons, RBAC tags, feature switches). These become your testing checklist in Stage 2.
+
+> ✅ **Output:** Wireframes or flow notes, file plan inside `metadata/authoring`, and acceptance bullets saved with the feature brief.
+
+---
+
+## Stage 2 – Build, Compile, and Test Locally
+
+**Goal:** Implement the metadata safely and confirm it works in a local environment.
+
+1. **Create or edit the XML.** Add your new files inside `metadata/authoring` based on the plan from Stage 1. Follow the patterns described in the Metadata Architecture Guide for layouts, data sources, and actions.【F:docs/architecture/metadata-architecture.md†L1-L34】
+2. **Validate structure early.** Run the metadata compiler to catch schema issues:
+   ```bash
+   npm run metadata:compile
+   ```
+   This command validates the XML, produces compiled JSON, and refreshes the manifest used by the app.【F:package.json†L7-L19】【F:tools/metadata/pipeline/compiler.ts†L15-L74】
+3. **Preview in the app.** Start the Next.js dev server with `npm run dev`, navigate to the affected pages, and confirm visuals match your acceptance notes.
+4. **Check RBAC directives in metadata.** Use `<RBAC>` tags or equivalent gating to hide controls from unauthorized roles. Note the exact permission keys—you will wire them up in Stage 4.
+5. **Update automated checks.** If the feature adds new data types or metadata IDs, ensure tests or snapshots that reference them are refreshed.
+6. **Document test results.** Update the acceptance notes with screenshots, console logs, and any follow-up items.
+
+> ✅ **Output:** Compiled metadata artifacts, local screenshots, and a short test log stored with the feature brief.
+
+---
+
+## Stage 3 – Configure Licensing Studio
+
+**Goal:** Make the feature easy to sell, bundle, and assign inside Licensing Studio.
+
+1. **Create or update the feature record.** In Licensing Studio, navigate to **Feature Bundles** and click **Add Features** to register the capability with a clear name and description.【F:docs/user-manual/licensing/licensing-studio-user-guide.md†L173-L216】
+2. **Place the feature in bundles.** Add it to the bundle(s) that represent how it will be sold. Mark the feature as *Required* if every subscriber of that bundle must receive it.【F:docs/user-manual/licensing/licensing-studio-user-guide.md†L217-L241】
+3. **Review product offerings.** Switch to the **Product Offerings** tab and confirm each tier includes the right bundles. Update pricing copy or notes if the new feature changes the value proposition.【F:docs/user-manual/licensing/licensing-studio-quick-start.md†L23-L38】
+4. **Plan customer migration (if needed).** Decide whether existing churches should automatically receive the feature. Coordinate with operations for any staged rollout.
+5. **Capture licensing decisions.** Record which bundles and offerings were touched, plus any launch conditions (e.g., "Enterprise-only until Q4"). Store this with the feature brief.
+
+> ✅ **Output:** Feature visible in Licensing Studio, bundle assignments updated, product tiers reviewed, and migration notes documented.
+
+---
+
+## Stage 4 – Align RBAC Roles & Permissions
+
+**Goal:** Guarantee that only the intended audiences can access the new capability.
+
+1. **Inventory existing roles.** Open the RBAC dashboard and review current role definitions to avoid duplicates. The RBAC manual recommends creating specific roles rather than overly broad ones.【F:RBAC_USER_MANUAL.md†L514-L524】
+2. **Create or update permission bundles.** If the feature introduces new actions, add them to a permission bundle so they can be reused across roles.【F:RBAC_USER_MANUAL.md†L153-L184】
+3. **Bind permissions to surfaces.** Use the Surface Binding Manager to connect the new metadata page or component to the appropriate roles or bundles.【F:RBAC_USER_MANUAL.md†L215-L247】
+4. **Test with role-based logins.** Impersonate or use test accounts for each target role. Verify the feature appears only for the correct combinations of licenses and permissions.
+5. **Schedule an RBAC review.** Have the security admin confirm mappings and document any temporary overrides or exceptions.
+
+> ✅ **Output:** Permission bundle updates, role assignments, surface bindings, and sign-off from the RBAC admin.
+
+---
+
+## Stage 5 – Launch Readiness & Go-Live
+
+**Goal:** Confirm that metadata, licensing, and RBAC align before opening the feature to real users.
+
+1. **Build the integrated checklist.** Merge the acceptance notes, licensing decisions, and RBAC confirmations into a single launch checklist.
+2. **Run pre-flight tests in staging.** Deploy to the staging environment, seed a test tenant with the new license bundle, and exercise the feature end-to-end (happy path + permission edge cases).
+3. **Verify telemetry or logging.** Ensure analytics events and audit logs capture usage for post-launch monitoring.
+4. **Train support and sales teams.** Share a short briefing covering what changed, who gets the feature, and how to troubleshoot access issues.
+5. **Hold the go/no-go meeting.** Review the checklist, confirm monitoring is live, and agree on the launch window and rollback plan.
+6. **Deploy and monitor.** After go-live, watch dashboards for usage and error trends. Keep a rollback or feature toggle plan handy for the first 24–48 hours.
+
+> ✅ **Output:** Signed launch checklist, deployment notes, and monitoring plan.
+
+---
+
+## Appendices
+
+### A. Documentation Templates
+- **Feature Brief Template:** Problem, target users, success metrics, licensing intent, RBAC impact, rollout plan.
+- **Acceptance Notes Template:** Metadata IDs touched, expected UI elements, data sources, RBAC keys, test results.
+- **Launch Checklist Template:** Metadata compiled ✔, Licensing bundles updated ✔, RBAC roles approved ✔, Staging smoke test date ✔, Support notified ✔.
+
+### B. Helpful Commands Reference
+- `npm run metadata:compile` – Validate and compile metadata before commits.【F:package.json†L7-L19】
+- `npm run metadata:watch` – Keep the compiler running while you edit XML so issues are caught immediately.【F:package.json†L10-L14】
+- `npm run dev` – Launch the local app for visual testing.
+- `npm run rbac:phase1` – Generate an inventory of current roles and permissions when planning RBAC updates.【F:package.json†L14-L15】
+
+### C. Roles & Responsibilities Cheat Sheet
+- **Product Owner:** Owns feature brief, licensing decisions, go/no-go call.
+- **Developer:** Authors metadata, runs compilers, validates RBAC hooks.
+- **Licensing Ops:** Maintains feature bundles and product offerings.
+- **Security Admin:** Approves RBAC changes and audits access.
+- **Support Lead:** Prepares communications and handles post-launch tickets.
+
+Keep this manual bookmarked. Updating it after each launch keeps the process smooth for the next feature.


### PR DESCRIPTION
## Summary
- add a step-by-step feature launch manual covering metadata work, Licensing Studio configuration, and RBAC alignment
- update the user manual index to highlight the new launch guide alongside existing Licensing Studio documentation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2b61191b48326b894d6c9532a4929