### PR TITLE
Fix lint warnings in RBAC services and integration tests

### DIFF
--- a/src/services/SidebarService.ts
+++ b/src/services/SidebarService.ts
@@ -232,7 +232,7 @@ export class SidebarService {
     }
 
     // Get both accessible and locked surfaces
-    const [accessibleSurfaces, lockedSurfaces] = await Promise.all([
+    const [_accessibleSurfaces, lockedSurfaces] = await Promise.all([
       this.userRoleService.getUserAccessibleSurfaces(userId, tenant.id),
       this.userRoleService.getLockedSurfaces(userId, tenant.id),
     ]);

--- a/src/services/UserMemberLinkService.ts
+++ b/src/services/UserMemberLinkService.ts
@@ -298,7 +298,7 @@ export class UserMemberLinkService {
           suggestions.push('Verify that this is the correct member for this user');
         }
       }
-    } catch (error) {
+    } catch {
       // Ignore errors in validation checks
     }
 

--- a/src/services/rbac.service.ts
+++ b/src/services/rbac.service.ts
@@ -486,7 +486,7 @@ export class RbacService {
     return this.publishingService.getMultiRoleStats(tenantId);
   }
 
-  async toggleMultiRoleMode(userId: string, enabled: boolean, tenantId?: string): Promise<any> {
+  async toggleMultiRoleMode(userId: string, enabled: boolean, _tenantId?: string): Promise<any> {
     // This would need implementation in core service
     // For now, return placeholder
     return { success: true, enabled };

--- a/src/services/rbacFeature.service.ts
+++ b/src/services/rbacFeature.service.ts
@@ -6,9 +6,7 @@ import type { ITenantFeatureGrantRepository } from '@/repositories/tenantFeature
 import { tenantUtils } from '@/utils/tenantUtils';
 import type {
   FeatureCatalog,
-  TenantFeatureGrant,
-  CreateRbacAuditLogInput,
-  RbacAuditOperation
+  TenantFeatureGrant
 } from '@/models/rbac.model';
 
 @injectable()

--- a/src/services/rbacMetadata.service.ts
+++ b/src/services/rbacMetadata.service.ts
@@ -9,9 +9,7 @@ import type {
   MetadataSurface,
   RbacSurfaceBinding,
   Permission,
-  CreateSurfaceBindingDto,
-  CreateRbacAuditLogInput,
-  RbacAuditOperation
+  CreateSurfaceBindingDto
 } from '@/models/rbac.model';
 
 @injectable()

--- a/src/tests/integration/rbac-database.test.ts
+++ b/src/tests/integration/rbac-database.test.ts
@@ -244,7 +244,6 @@ describe('RBAC Database Functions Integration Tests', () => {
 
   describe('Surface Bindings', () => {
     let testMenuItemId: string;
-    let testSurfaceBindingId: string;
 
     beforeEach(async () => {
       if (process.env.NODE_ENV !== 'test') {
@@ -278,7 +277,8 @@ describe('RBAC Database Functions Integration Tests', () => {
           .single();
 
         if (!bindingError) {
-          testSurfaceBindingId = binding.id;
+          // Ensure the binding was created
+          expect(binding.id).toBeDefined();
         }
       }
     });
@@ -385,7 +385,7 @@ describe('RBAC Database Functions Integration Tests', () => {
         return;
       }
 
-      const { data, error } = await supabase.rpc('refresh_tenant_user_effective_permissions_safe');
+      const { data: _data, error } = await supabase.rpc('refresh_tenant_user_effective_permissions_safe');
 
       // Should not error (though may not have permissions in test environment)
       expect(error).toBeNull();


### PR DESCRIPTION
## Summary
- silence unused variable warnings in the sidebar service and RBAC service layer
- remove unused RBAC model imports from feature and metadata services
- tighten integration test setup to assert created bindings and avoid unused variables

## Testing
- npx eslint src/services/SidebarService.ts src/services/UserMemberLinkService.ts src/services/rbac.service.ts src/services/rbacFeature.service.ts src/services/rbacMetadata.service.ts src/tests/integration/rbac-database.test.ts
- npx tsc --noEmit *(fails: repository currently has unrelated type errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68e36cc9778c83269199f5b360ee2471