### PR TITLE
Fix lint issues in onboarding and auth pages

### DIFF
--- a/src/adapters/userRoleManagement.adapter.ts
+++ b/src/adapters/userRoleManagement.adapter.ts
@@ -603,7 +603,7 @@ export class UserRoleManagementAdapter extends BaseAdapter<UserRole> implements 
       const userIds = tenantUsers.map(tu => tu.user_id);
 
       // Fetch auth.users data via RPC
-      let authUsersMap = new Map<string, AuthUserRow>();
+      const authUsersMap = new Map<string, AuthUserRow>();
       try {
         const { data: authUsersData, error: authUsersError } = await supabase
           .rpc('get_user_profiles', { user_ids: userIds });

--- a/src/app/(protected)/onboarding/page.tsx
+++ b/src/app/(protected)/onboarding/page.tsx
@@ -119,7 +119,7 @@ export default function OnboardingPage() {
             Welcome to StewardTrack
           </h1>
           <p className="text-muted-foreground">
-            Let's get your church management system set up
+            Let&rsquo;s get your church management system set up
           </p>
         </div>
 

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -139,7 +139,7 @@ export default function LoginPage() {
               </div>
               <div className="flex-1">
                 <p className="text-sm font-medium text-foreground">
-                  "StewardTrack has saved our church 10+ hours per week on administrative tasks."
+                  &ldquo;StewardTrack has saved our church 10+ hours per week on administrative tasks.&rdquo;
                 </p>
                 <p className="mt-2 text-xs text-muted-foreground">
                   - Pastor Michael J., Grace Community Church

--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -262,29 +263,29 @@ export default function SignupPage() {
         {/* FAQ Callout */}
         <div className="mx-auto max-w-2xl rounded-xl border border-border/60 bg-card/50 p-6 backdrop-blur-sm">
           <h3 className="text-center font-semibold text-foreground mb-4">
-            Questions? We're Here to Help
+            Questions? We&rsquo;re Here to Help
           </h3>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
+            <Link
               href="/#faq"
               className="inline-flex items-center justify-center gap-2 text-sm font-medium text-primary hover:underline"
             >
               View FAQ
-            </a>
+            </Link>
             <span className="hidden sm:inline text-muted-foreground">•</span>
-            <a
+            <Link
               href="/contact"
               className="inline-flex items-center justify-center gap-2 text-sm font-medium text-primary hover:underline"
             >
               Contact Sales
-            </a>
+            </Link>
             <span className="hidden sm:inline text-muted-foreground">•</span>
-            <a
+            <Link
               href="/demo"
               className="inline-flex items-center justify-center gap-2 text-sm font-medium text-primary hover:underline"
             >
               Schedule Demo
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/app/admin/onboarding/page.tsx
+++ b/src/app/admin/onboarding/page.tsx
@@ -119,7 +119,7 @@ export default function OnboardingPage() {
             Welcome to StewardTrack
           </h1>
           <p className="text-muted-foreground">
-            Let's get your church management system set up
+            Let&rsquo;s get your church management system set up
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- escape apostrophes and quotes in onboarding and authentication marketing copy to satisfy lint rules
- replace plain anchor elements with Next.js Link in the signup FAQ section
- switch the auth user map in the role management adapter to a const declaration for lint compliance

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e36f149e5c832687d47aa7ebe53365