### PR TITLE
Fix route handler context type for feature bundle features endpoint

### DIFF
--- a/src/app/api/licensing/feature-bundles/[id]/features/route.ts
+++ b/src/app/api/licensing/feature-bundles/[id]/features/route.ts
@@ -3,20 +3,20 @@ import { container } from '@/lib/container';
 import { TYPES } from '@/lib/types';
 import { LicensingService } from '@/services/LicensingService';
 
-interface RouteParams {
-  params: {
+interface RouteContext {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 /**
  * GET /api/licensing/feature-bundles/[id]/features
  * Retrieves features for a specific license feature bundle
  */
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export async function GET(request: NextRequest, context: RouteContext) {
   try {
     // Await params in Next.js 15
-    const { id } = await params;
+    const { id } = await context.params;
 
     const licensingService = container.get<LicensingService>(TYPES.LicensingService);
 


### PR DESCRIPTION
## Summary
- align the feature bundle features route handler context type with Next.js 15 expectations
- await the params from the provided context instead of destructuring directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e376bb1d408326935c4e870f26f8b0