### PR TITLE
Fix route params typing for dynamic API handlers

### DIFF
--- a/src/app/api/member-invitations/[id]/resend/route.ts
+++ b/src/app/api/member-invitations/[id]/resend/route.ts
@@ -6,9 +6,9 @@ import { authUtils } from '@/utils/authUtils';
 import { tenantUtils } from '@/utils/tenantUtils';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 // POST /api/member-invitations/[id]/resend - Resend invitation
@@ -25,8 +25,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const userMemberLinkService = container.get<UserMemberLinkService>(TYPES.UserMemberLinkService);
+    const { id } = await params;
 
-    const invitation = await userMemberLinkService.resendInvitation(params.id, user.id, tenantId);
+    const invitation = await userMemberLinkService.resendInvitation(id, user.id, tenantId);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/member-invitations/[id]/route.ts
+++ b/src/app/api/member-invitations/[id]/route.ts
@@ -6,9 +6,9 @@ import { authUtils } from '@/utils/authUtils';
 import { tenantUtils } from '@/utils/tenantUtils';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 // GET /api/member-invitations/[id] - Get specific invitation
@@ -25,8 +25,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const userMemberLinkService = container.get<UserMemberLinkService>(TYPES.UserMemberLinkService);
+    const { id } = await params;
 
-    const invitation = await userMemberLinkService.getInvitationById(params.id, tenantId);
+    const invitation = await userMemberLinkService.getInvitationById(id, tenantId);
 
     if (!invitation) {
       return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
@@ -59,9 +60,10 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const { reason } = body;
 
     const userMemberLinkService = container.get<UserMemberLinkService>(TYPES.UserMemberLinkService);
+    const { id } = await params;
 
     const result = await userMemberLinkService.revokeInvitation(
-      params.id,
+      id,
       user.id,
       reason,
       tenantId

--- a/src/app/api/rbac/bundles/[id]/route.ts
+++ b/src/app/api/rbac/bundles/[id]/route.ts
@@ -5,9 +5,9 @@ import { RbacService } from '@/services/rbac.service';
 import { UpdatePermissionBundleDto } from '@/models/rbac.model';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {

--- a/src/app/api/rbac/roles/[id]/route.ts
+++ b/src/app/api/rbac/roles/[id]/route.ts
@@ -5,9 +5,9 @@ import { RbacService } from '@/services/rbac.service';
 import { UpdateRoleDto } from '@/models/rbac.model';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {

--- a/src/app/api/rbac/users/[userId]/roles/[roleId]/route.ts
+++ b/src/app/api/rbac/users/[userId]/roles/[roleId]/route.ts
@@ -4,17 +4,19 @@ import { TYPES } from '@/lib/types';
 import { RbacService } from '@/services/rbac.service';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     userId: string;
     roleId: string;
-  };
+  }>;
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const rbacService = container.get<RbacService>(TYPES.RbacService);
 
-    await rbacService.revokeRole(params.userId, params.roleId);
+    const { userId, roleId } = await params;
+
+    await rbacService.revokeRole(userId, roleId);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/rbac/users/[userId]/roles/route.ts
+++ b/src/app/api/rbac/users/[userId]/roles/route.ts
@@ -5,9 +5,9 @@ import { RbacService } from '@/services/rbac.service';
 import { AssignRoleDto } from '@/models/rbac.model';
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     userId: string;
-  };
+  }>;
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
@@ -16,7 +16,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const tenantId = searchParams.get('tenantId') || undefined;
 
-    const userWithRoles = await rbacService.getUserWithRoles(params.userId, tenantId);
+    const { userId } = await params;
+
+    const userWithRoles = await rbacService.getUserWithRoles(userId, tenantId);
 
     if (!userWithRoles) {
       return NextResponse.json(
@@ -59,8 +61,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    const { userId } = await params;
+
     const assignRoleDto: AssignRoleDto = {
-      user_id: params.userId,
+      user_id: userId,
       role_id: body.role_id,
       expires_at: body.expires_at
     };


### PR DESCRIPTION
## Summary
- update dynamic API route handler contexts to use awaitable params that satisfy Next.js typing
- resolve awaited params before invoking services so handlers work with typed routes

## Testing
- npx tsc --noEmit *(fails: existing repository type errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3797b7a908326bbf99d07add21dce