### PR TITLE
Fix delegation permission route handler context typing

### DIFF
--- a/src/app/api/rbac/delegation/permissions/[id]/route.ts
+++ b/src/app/api/rbac/delegation/permissions/[id]/route.ts
@@ -5,12 +5,12 @@ import { RbacService } from '@/services/rbac.service';
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const rbacService = container.get<RbacService>(TYPES.RbacService);
     const body = await request.json();
-    const { id } = params;
+    const { id } = await params;
 
     const updatedPermission = await rbacService.updateDelegationPermission(id, body);
 
@@ -32,11 +32,11 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const rbacService = container.get<RbacService>(TYPES.RbacService);
-    const { id } = params;
+    const { id } = await params;
 
     await rbacService.revokeDelegationPermission(id);
 


### PR DESCRIPTION
## Summary
- update delegation permission PUT and DELETE handlers to await the params promise and satisfy the expected RouteHandlerConfig typing

## Testing
- npm run lint -- src/app/api/rbac/delegation/permissions/[id]/route.ts

------
https://chatgpt.com/codex/tasks/task_e_68e37bbb73248326b3bea36768d4a246