### PR TITLE
Fix route context param typing for Next.js 15

### DIFF
--- a/src/app/api/rbac/publishing/jobs/[jobId]/cancel/route.ts
+++ b/src/app/api/rbac/publishing/jobs/[jobId]/cancel/route.ts
@@ -4,15 +4,15 @@ import { TYPES } from '@/lib/types';
 import { RbacService } from '@/services/rbac.service';
 
 type RouteContext = {
-  params: {
+  params: Promise<{
     jobId: string;
-  };
+  }>;
 };
 
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
     const tenantId = request.nextUrl.searchParams.get('tenantId') ?? undefined;
-    const { jobId } = context.params;
+    const { jobId } = await context.params;
     const rbacService = container.get<RbacService>(TYPES.RbacService);
     const job = await rbacService.cancelPublishingJob(jobId, tenantId);
 

--- a/src/app/api/user-member-link/invitations/[id]/resend/route.ts
+++ b/src/app/api/user-member-link/invitations/[id]/resend/route.ts
@@ -4,15 +4,15 @@ import { TYPES } from '@/lib/types';
 import { UserMemberLinkService } from '@/services/UserMemberLinkService';
 
 interface RouteContext {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export async function POST(request: Request, context: RouteContext) {
   try {
     const userMemberLinkService = container.get<UserMemberLinkService>(TYPES.UserMemberLinkService);
-    const { id: invitationId } = context.params;
+    const { id: invitationId } = await context.params;
 
     // Check if invitation exists and get its current status
     const invitation = await userMemberLinkService.getInvitationById(invitationId);


### PR DESCRIPTION
## Summary
- update Next.js route handler context typing to await the params promise introduced in Next.js 15
- ensure publishing job cancel and user-member invitation resend APIs correctly resolve route parameters before use

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e37d1ddc1c832697ab37397d901794