### PR TITLE
Expand audit action types for license assignments

### DIFF
--- a/src/services/AuditService.ts
+++ b/src/services/AuditService.ts
@@ -1,10 +1,10 @@
 import 'server-only';
 import { injectable } from 'inversify';
-import { logAuditEvent } from '@/utils/auditLogger';
+import { logAuditEvent, type AuditAction } from '@/utils/auditLogger';
 
 export interface AuditService {
   logAuditEvent(
-    action: 'create' | 'update' | 'delete',
+    action: AuditAction,
     entityType: string,
     entityId: string,
     changes: Record<string, any>
@@ -14,7 +14,7 @@ export interface AuditService {
 @injectable()
 export class SupabaseAuditService implements AuditService {
   async logAuditEvent(
-    action: 'create' | 'update' | 'delete',
+    action: AuditAction,
     entityType: string,
     entityId: string,
     changes: Record<string, any>

--- a/src/utils/auditLogger.ts
+++ b/src/utils/auditLogger.ts
@@ -1,7 +1,9 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
+export type AuditAction = 'create' | 'update' | 'delete' | 'assign_license';
+
 export async function logAuditEvent(
-  action: 'create' | 'update' | 'delete',
+  action: AuditAction,
   entityType: string,
   entityId: string,
   changes: Record<string, unknown>


### PR DESCRIPTION
## Summary
- add a reusable AuditAction type that includes the assign_license action for custom audit events
- update the audit service implementation to consume the shared AuditAction type so license assignments can be logged

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e38176a86883269a7a1ade7a507405