### PR TITLE
Fix type narrowing for license assignment details query

### DIFF
--- a/src/adapters/licenseAssignment.adapter.ts
+++ b/src/adapters/licenseAssignment.adapter.ts
@@ -44,6 +44,35 @@ export interface ILicenseAssignmentAdapter extends IBaseAdapter<LicenseAssignmen
   getAssignmentWithDetails(assignmentId: string): Promise<LicenseAssignmentWithDetails | null>;
 }
 
+type LicenseAssignmentDetailsRecord = LicenseAssignment & {
+  product_offerings?: {
+    name?: string | null;
+    tier?: string | null;
+  } | null;
+  previous_offering?: {
+    name?: string | null;
+  } | null;
+  assigned_by_user?: {
+    email?: string | null;
+  } | null;
+};
+
+const isLicenseAssignmentDetailsRecord = (
+  value: unknown
+): value is LicenseAssignmentDetailsRecord => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const record = value as Partial<LicenseAssignmentDetailsRecord>;
+
+  return (
+    typeof record.id === 'string' &&
+    typeof record.tenant_id === 'string' &&
+    typeof record.offering_id === 'string'
+  );
+};
+
 @injectable()
 export class LicenseAssignmentAdapter
   extends BaseAdapter<LicenseAssignment>
@@ -257,6 +286,10 @@ export class LicenseAssignmentAdapter
 
     if (!data) {
       return null;
+    }
+
+    if (!isLicenseAssignmentDetailsRecord(data)) {
+      throw new Error('Failed to parse assignment details from Supabase response');
     }
 
     return {


### PR DESCRIPTION
## Summary
- add a runtime type guard for the license assignment details query to ensure the expected fields are present
- surface a clear error when Supabase returns an unexpected payload before building the response object

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3adc34cfc8326b24232930d890996