### PR TITLE
Fix spread type error in license feature bundle adapter

### DIFF
--- a/src/adapters/licenseFeatureBundle.adapter.ts
+++ b/src/adapters/licenseFeatureBundle.adapter.ts
@@ -107,10 +107,11 @@ export class LicenseFeatureBundleAdapter
       return null;
     }
 
+    const bundleData = bundle as LicenseFeatureBundle;
     const features = await this.getBundleFeatures(bundleId);
 
     return {
-      ...bundle,
+      ...bundleData,
       features,
       feature_count: features.length,
     };


### PR DESCRIPTION
## Summary
- cast the Supabase bundle result to LicenseFeatureBundle before spreading to resolve the TS spread type error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ed6fbcf483269d014a5205a9c963