### PR TITLE
Fix spread typing for license bundle features

### DIFF
--- a/src/adapters/licenseFeatureBundle.adapter.ts
+++ b/src/adapters/licenseFeatureBundle.adapter.ts
@@ -111,14 +111,16 @@ export class LicenseFeatureBundleAdapter
       throw new Error('Invalid license feature bundle data received');
     }
 
-    const bundleData = bundle;
+    const bundleData: LicenseFeatureBundle = bundle;
     const features = await this.getBundleFeatures(bundleId);
 
-    return {
+    const bundleWithFeatures: LicenseFeatureBundleWithFeatures = {
       ...bundleData,
       features,
       feature_count: features.length,
     };
+
+    return bundleWithFeatures;
   }
 
   async getActiveBundles(): Promise<LicenseFeatureBundle[]> {


### PR DESCRIPTION
## Summary
- ensure license feature bundle data is typed before spreading
- return a typed bundle-with-features object to satisfy TypeScript

## Testing
- npx tsc --noEmit *(fails: existing test type definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f5c4642883269a78e5a83470f355