### PR TITLE
Fix mobile admin sidebar scrolling

### DIFF
--- a/src/components/admin/sidebar-nav.tsx
+++ b/src/components/admin/sidebar-nav.tsx
@@ -123,7 +123,7 @@ export function AdminSidebar({
           <div className="flex items-center gap-3 px-5 pb-5 pt-12">
             <SidebarBrand showLabels className="gap-3" />
           </div>
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="space-y-8 px-4 pb-10">
               {navSections.map((section) => (
                 <div key={section.label} className="space-y-2">


### PR DESCRIPTION
## Summary
- allow the mobile admin navigation sheet to shrink its scroll area so the menu can be scrolled on small screens

## Testing
- npm run lint *(fails: ESLint is configured to ignore all files when linting from the repository root)*

------
https://chatgpt.com/codex/tasks/task_e_68e5144b64148326b83c9eaa18b68d8c